### PR TITLE
Initial version of migration script to load treetracker.capture from public.trees table

### DIFF
--- a/database/knex.js
+++ b/database/knex.js
@@ -1,7 +1,7 @@
 const expect = require("expect-runtime");
 const connection = process.env.DATABASE_URL
 expect(connection).to.match(/^postgresql:\//);
-const urlregexp = /postgresql:\/\/(.+):(.+)@(.+):(\d+)\/(.+)\?ssl=true/g;
+const urlregexp = /postgresql:\/\/(.+):(.+)@(.+):(\d+)\/(.+)/g;
 const dbConnValues = [...connection.matchAll(urlregexp)][0];
 
 let knexConfig = {

--- a/database/knex.js
+++ b/database/knex.js
@@ -1,11 +1,20 @@
 const expect = require("expect-runtime");
 const connection = process.env.DATABASE_URL
 expect(connection).to.match(/^postgresql:\//);
+const urlregexp = /postgresql:\/\/(.+):(.+)@(.+):(\d+)\/(.+)\?ssl=true/g;
+const dbConnValues = [...connection.matchAll(urlregexp)][0];
 
 let knexConfig = {
   client: "pg",
   debug: process.env.NODE_LOG_LEVEL === "debug" ? true : false,
-  connection: connection,
+  connection: {
+    host: dbConnValues[3],
+    user: dbConnValues[1],
+    password: dbConnValues[2],
+    database: dbConnValues[5],
+    port: dbConnValues[4],
+    ssl: { rejectUnauthorized: false }
+  },
   pool: { min: 0, max: 10 },
 };
 

--- a/migrate_legacy_captures.js
+++ b/migrate_legacy_captures.js
@@ -1,116 +1,102 @@
 /**
- *  This is a migration script that is to get all the records from legacy `public.tree` and populate 
+ *  This is a migration script that is to get all the records from legacy `public.tree` and populate
  *  table `treetracker.capture` as long as the legacy records in `public.trees` are approved,
- *  active, has a valid image url and if legacy data has not made it to capture table already. 
- *  In addition, if the concept of planter referenced in legacy trees table is not found in the 
+ *  active, has a valid image url and if legacy data has not made it to capture table already.
+ *  In addition, if the concept of planter referenced in legacy trees table is not found in the
  *  `treetracker.grower_account`, it is created first using the data from `public.planter` before proceeding
  *  with populating the `treetracker.captures` table.
- * 
+ *
  *  @created Jan 28 2022
  *
  * */
 
 require("dotenv").config();
-const generate_uuid_v4 = require('uuid').v4;
+const generate_uuid_v4 = require("uuid").v4;
 
 const { knex } = require("./database/knex");
-const Writable = require('stream').Writable;
+const Writable = require("stream").Writable;
 const ws = Writable({ objectMode: true });
 const ProgressBar = require("progress");
-
 
 async function ensureGrowerAccountExists(legacyTree, transaction) {
   let planter = null;
   if (!legacyTree.planter_identifier && !legacyTree.planter_id) {
-     throw Error("No planter record found in legacy tree table");
+    throw Error("No planter record found in legacy tree table");
   }
   if (legacyTree.planter_id) {
     planter = await transaction
-            .select()
-            .table('public.planter')
-            .where('id', legacyTree.planter_id)
-            .first();
-  } else if(legacyTree.planter_identifier && legacyTree.planter_identifier.trim()) {
+      .select()
+      .table("public.planter")
+      .where("id", legacyTree.planter_id)
+      .first();
+  } else if (
+    legacyTree.planter_identifier &&
+    legacyTree.planter_identifier.trim()
+  ) {
     planter = await transaction
-            .select()
-            .table('public.planter')
-            .where('email', legacyTree.planter_identifier)
-            .orWhere('phone', legacyTree.planter_identifier)
-            .first();
+      .select()
+      .table("public.planter")
+      .where("email", legacyTree.planter_identifier)
+      .orWhere("phone", legacyTree.planter_identifier)
+      .first();
   }
   if (!planter) {
-    throw Error(`No planter record found for tree entry with id ${legacyTree.id}`);
+    throw Error(
+      `No planter record found for tree entry with id ${legacyTree.id}`
+    );
   }
-  let growerAccount = await transaction('treetracker.grower_account')
-                      .where('email', planter.email)
-                      .orWhere('phone', planter.phone)
-                      .first();
+  let growerAccount = await transaction("treetracker.grower_account")
+    .where("email", planter.email)
+    .orWhere("phone", planter.phone)
+    .first();
   if (!growerAccount) {
-    console.log(`GrowerAccount not found for planter_identifier ${legacyTree.planter_identifier}`);
-    console.log(`Populating grower account for ${legacyTree.planter_identifier}`);
+    console.log(
+      `GrowerAccount not found for planter_identifier ${legacyTree.planter_identifier}`
+    );
+    console.log(
+      `Populating grower account for ${legacyTree.planter_identifier}`
+    );
     // status, first_registration_at aren't available in the source `public.planter` table
     // Is it ok, if the above attributes take the db defaults?
-    growerAccount = await transaction('treetracker.grower_account').insert({
-      name: planter.first_name + ' '+planter.last_name,
-      email: planter.email,
-      phone: planter.phone,
-      image_url: planter.image_url ?? legacyTree.planter_photo_url,  //should this be public.trees.planter_photo_url?
-      image_rotation: planter.image_rotation ?? 0,
-      organization_id: planter.organization_id,
-      wallet_id: generate_uuid_v4(), // TODO: temporary workaround, needs to be a specific uuid and not a newly generated one.
-      wallet: "Temporary placeholder",
-      first_registration_at: new Date()
-    }, ['id', 'wallet_id', 'name', 'email', 'phone', 'organization_id', 'image_url', 'image_rotation']);
+    growerAccount = await transaction("treetracker.grower_account").insert(
+      {
+        name: planter.first_name + " " + planter.last_name,
+        email: planter.email,
+        phone: planter.phone,
+        image_url: planter.image_url ?? legacyTree.planter_photo_url, //should this be public.trees.planter_photo_url?
+        image_rotation: planter.image_rotation ?? 0,
+        organization_id: planter.organization_id,
+        wallet_id: generate_uuid_v4(), // TODO: temporary workaround, needs to be a specific uuid and not a newly generated one.
+        wallet: "Temporary placeholder",
+        first_registration_at: new Date(),
+      },
+      [
+        "id",
+        "wallet_id",
+        "name",
+        "email",
+        "phone",
+        "organization_id",
+        "image_url",
+        "image_rotation",
+      ]
+    );
   }
   console.log(`GrowerAccount exists: ${JSON.stringify(growerAccount)}`);
-  return growerAccount
+  return growerAccount;
 }
 
-ws._write = async (legacyTree, enc, next) => {
-  const transaction = await knex.transaction();
-  try {
-    let growerAcount = await ensureGrowerAccountExists(legacyTree, transaction);
-    const treeAttributes = await trx
-      .select()
-      .table("public.tree_attributes")
-      .where("tree_id", +legacyTree.id);
-
-    const captureToInsert = createCapture(legacyTree, treeAttributes, growerAccount);
-    const { lat, lon } = captureToInsert;
-    await transaction.raw(
-      `insert into treetracker.capture (
-        reference_id, image_url, lat, lon, gps_accuracy, grower_id, grower_photo_url, grower_username,
-        morphology, age, note, attributes, created_at, updated_at, device_configuration_id, session_id,
-        estimated_geometric_location, estimated_geographic_location 
-      )
-      values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-          ST_PointFromText(?, 4325), ST_SetSRID(ST_PointFromText(?, 4326)))`,
-      [ captureToInsert.id, captureToInsert.image_url, captureToInsert.lat, captureToInsert.lon, captureToInsert.gps_accuracy,
-        captureToInsert.grower_id, captureToInsert.grower_photo_url, captureToInsert.grower_username,  captureToInsert.morphology,
-        captureToInsert.age, captureToInsert.note, captureToInsert.attributes, captureToInsert.created_at,
-        captureToInsert.updated_at, captureToInsert.device_configuration_id, captureToInsert.session_id,
-        "POINT(" + lon + " " + lat + ")", "POINT(" + lon + " " + lat +")"]);
-    transaction.commit();
-    bar.tick();
-    if (bar.complete) {
-      console.log("Migration Complete");
-    }
-  } catch (e) {
-    console.log(`Error processing tree id ${legacyTree.id} ${e}`);
-    transaction.rollback();
-  }
-  next();
-}
-    
 async function migrate() {
   try {
     const base_query_string = `select t.* from public.trees t left join treetracker.capture c on t.id = c.reference_id
                                 where t.active=true and t.approved=true and t.image_url != null and
                                 c.reference_id is null`;
-    const rowCountResult = await knex.select(knex.raw(`count(1) from (${base_query_string}) as src`));
+    const rowCountResult = await knex.select(
+      knex.raw(`count(1) from (${base_query_string}) as src`)
+    );
     console.log(`Migrating ${+rowCountResult[0].count} records`);
-    
-    var bar = new ProgressBar("Migrating [:bar] :percent :etas", {
+
+    const bar = new ProgressBar("Migrating [:bar] :percent :etas", {
       width: 20,
       total: +rowCountResult[0].count,
     });
@@ -149,7 +135,7 @@ async function migrate() {
         gps_accuracy: gps_accuracy,
         grower_id: growerAccount.id,
         grower_photo_url: planter_photo_url,
-        grower_username: '-', //TODO: What should be used for username here?
+        grower_username: "-", //TODO: What should be used for username here?
         morphology: morphology,
         age: age,
         note: note,
@@ -161,10 +147,69 @@ async function migrate() {
       });
     };
 
+    ws._write = async (legacyTree, enc, next) => {
+      const transaction = await knex.transaction();
+      try {
+        let growerAcount = await ensureGrowerAccountExists(
+          legacyTree,
+          transaction
+        );
+        const treeAttributes = await trx
+          .select()
+          .table("public.tree_attributes")
+          .where("tree_id", +legacyTree.id);
+
+        const captureToInsert = createCapture(
+          legacyTree,
+          treeAttributes,
+          growerAccount
+        );
+        const { lat, lon } = captureToInsert;
+        await transaction.raw(
+          `insert into treetracker.capture (
+        reference_id, image_url, lat, lon, gps_accuracy, grower_id, grower_photo_url, grower_username,
+        morphology, age, note, attributes, created_at, updated_at, device_configuration_id, session_id,
+        estimated_geometric_location, estimated_geographic_location 
+      )
+      values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+          ST_PointFromText(?, 4325), ST_SetSRID(ST_PointFromText(?, 4326)))`,
+          [
+            captureToInsert.id,
+            captureToInsert.image_url,
+            captureToInsert.lat,
+            captureToInsert.lon,
+            captureToInsert.gps_accuracy,
+            captureToInsert.grower_id,
+            captureToInsert.grower_photo_url,
+            captureToInsert.grower_username,
+            captureToInsert.morphology,
+            captureToInsert.age,
+            captureToInsert.note,
+            captureToInsert.attributes,
+            captureToInsert.created_at,
+            captureToInsert.updated_at,
+            captureToInsert.device_configuration_id,
+            captureToInsert.session_id,
+            "POINT(" + lon + " " + lat + ")",
+            "POINT(" + lon + " " + lat + ")",
+          ]
+        );
+        transaction.commit();
+        bar.tick();
+        if (bar.complete) {
+          console.log("Migration Complete");
+        }
+      } catch (e) {
+        console.log(`Error processing tree id ${legacyTree.id} ${e}`);
+        transaction.rollback();
+      }
+      next();
+    };
+
     if (rowCountResult > 0) {
       const stream = knex.raw(`${base_query_string}`).stream();
       stream.pipe(ws);
-    } 
+    }
   } catch (err) {
     console.log(err);
   }

--- a/migrate_legacy_captures.js
+++ b/migrate_legacy_captures.js
@@ -157,7 +157,7 @@ async function migrate() {
         const treeAttributes = await trx
           .select()
           .table("public.tree_attributes")
-          .where("tree_id", +legacyTree.id);
+          .where("tree_id", legacyTree.id);
 
         const captureToInsert = createCapture(
           legacyTree,
@@ -174,7 +174,7 @@ async function migrate() {
       values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
           ST_PointFromText(?, 4325), ST_SetSRID(ST_PointFromText(?, 4326)))`,
           [
-            captureToInsert.id,
+            captureToInsert.reference_id,
             captureToInsert.image_url,
             captureToInsert.lat,
             captureToInsert.lon,

--- a/migrate_legacy_captures.js
+++ b/migrate_legacy_captures.js
@@ -46,8 +46,8 @@ async function ensureGrowerAccountExists(legacyTree, transaction) {
     );
   }
   let growerAccount = await transaction("treetracker.grower_account")
-    .where("email", planter.email)
-    .orWhere("phone", planter.phone)
+    .where("wallet", planter.email)
+    .orWhere("wallet", planter.phone)
     .first();
   if (!growerAccount) {
     console.log(
@@ -67,7 +67,7 @@ async function ensureGrowerAccountExists(legacyTree, transaction) {
         image_rotation: planter.image_rotation ?? 0,
         organization_id: planter.organization_id,
         wallet_id: generate_uuid_v4(), // TODO: temporary workaround, needs to be a specific uuid and not a newly generated one.
-        wallet: "Temporary placeholder",
+        wallet: planter.email ?? planter.phone,
         first_registration_at: new Date(),
       },
       [

--- a/migrate_legacy_captures.js
+++ b/migrate_legacy_captures.js
@@ -1,0 +1,173 @@
+/**
+ *  This is a migration script that is to get all the records from legacy `public.tree` and populate 
+ *  table `treetracker.capture` as long as the legacy records in `public.trees` are approved,
+ *  active, has a valid image url and if legacy data has not made it to capture table already. 
+ *  In addition, if the concept of planter referenced in legacy trees table is not found in the 
+ *  `treetracker.grower_account`, it is created first using the data from `public.planter` before proceeding
+ *  with populating the `treetracker.captures` table.
+ * 
+ *  @created Jan 28 2022
+ *
+ * */
+
+require("dotenv").config();
+const generate_uuid_v4 = require('uuid').v4;
+
+const { knex } = require("./database/knex");
+const Writable = require('stream').Writable;
+const ws = Writable({ objectMode: true });
+const ProgressBar = require("progress");
+
+
+async function ensureGrowerAccountExists(legacyTree, transaction) {
+  let planter = null;
+  if (!legacyTree.planter_identifier && !legacyTree.planter_id) {
+     throw Error("No planter record found in legacy tree table");
+  }
+  if (legacyTree.planter_id) {
+    planter = await transaction
+            .select()
+            .table('public.planter')
+            .where('id', legacyTree.planter_id)
+            .first();
+  } else if(legacyTree.planter_identifier && legacyTree.planter_identifier.trim()) {
+    planter = await transaction
+            .select()
+            .table('public.planter')
+            .where('email', legacyTree.planter_identifier)
+            .orWhere('phone', legacyTree.planter_identifier)
+            .first();
+  }
+  if (!planter) {
+    throw Error(`No planter record found for tree entry with id ${legacyTree.id}`);
+  }
+  let growerAccount = await transaction('treetracker.grower_account')
+                      .where('email', planter.email)
+                      .orWhere('phone', planter.phone)
+                      .first();
+  if (!growerAccount) {
+    console.log(`GrowerAccount not found for planter_identifier ${legacyTree.planter_identifier}`);
+    console.log(`Populating grower account for ${legacyTree.planter_identifier}`);
+    // status, first_registration_at aren't available in the source `public.planter` table
+    // Is it ok, if the above attributes take the db defaults?
+    growerAccount = await transaction('treetracker.grower_account').insert({
+      name: planter.first_name + ' '+planter.last_name,
+      email: planter.email,
+      phone: planter.phone,
+      image_url: planter.image_url ?? legacyTree.planter_photo_url,  //should this be public.trees.planter_photo_url?
+      image_rotation: planter.image_rotation ?? 0,
+      organization_id: planter.organization_id,
+      wallet_id: generate_uuid_v4(), // TODO: temporary workaround, needs to be a specific uuid and not a newly generated one.
+      wallet: "Temporary placeholder",
+      first_registration_at: new Date()
+    }, ['id', 'wallet_id', 'name', 'email', 'phone', 'organization_id', 'image_url', 'image_rotation']);
+  }
+  console.log(`GrowerAccount exists: ${JSON.stringify(growerAccount)}`);
+  return growerAccount
+}
+
+ws._write = async (legacyTree, enc, next) => {
+  const transaction = await knex.transaction();
+  try {
+    let growerAcount = await ensureGrowerAccountExists(legacyTree, transaction);
+    const treeAttributes = await trx
+      .select()
+      .table("public.tree_attributes")
+      .where("tree_id", +legacyTree.id);
+
+    const captureToInsert = createCapture(legacyTree, treeAttributes, growerAccount);
+    const { lat, lon } = captureToInsert;
+    await transaction.raw(
+      `insert into treetracker.capture (
+        reference_id, image_url, lat, lon, gps_accuracy, grower_id, grower_photo_url, grower_username,
+        morphology, age, note, attributes, created_at, updated_at, device_configuration_id, session_id,
+        estimated_geometric_location, estimated_geographic_location 
+      )
+      values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+          ST_PointFromText(?, 4325), ST_SetSRID(ST_PointFromText(?, 4326)))`,
+      [ captureToInsert.id, captureToInsert.image_url, captureToInsert.lat, captureToInsert.lon, captureToInsert.gps_accuracy,
+        captureToInsert.grower_id, captureToInsert.grower_photo_url, captureToInsert.grower_username,  captureToInsert.morphology,
+        captureToInsert.age, captureToInsert.note, captureToInsert.attributes, captureToInsert.created_at,
+        captureToInsert.updated_at, captureToInsert.device_configuration_id, captureToInsert.session_id,
+        "POINT(" + lon + " " + lat + ")", "POINT(" + lon + " " + lat +")"]);
+    transaction.commit();
+    bar.tick();
+    if (bar.complete) {
+      console.log("Migration Complete");
+    }
+  } catch (e) {
+    console.log(`Error processing tree id ${legacyTree.id} ${e}`);
+    transaction.rollback();
+  }
+  next();
+}
+    
+async function migrate() {
+  try {
+    const base_query_string = `select t.* from public.trees t left join treetracker.capture c on t.id = c.reference_id
+                                where t.active=true and t.approved=true and t.image_url != null and
+                                c.reference_id is null`;
+    const rowCountResult = await knex.select(knex.raw(`count(1) from (${base_query_string}) as src`));
+    console.log(`Migrating ${+rowCountResult[0].count} records`);
+    
+    var bar = new ProgressBar("Migrating [:bar] :percent :etas", {
+      width: 20,
+      total: +rowCountResult[0].count,
+    });
+
+    const attributesFormatter = (attributes) => {
+      if (attributes.length <= 0) return null;
+      const attributes_in_json_format = { entries: [] };
+      for (let entry of attributes) {
+        attributes_in_json_format.entries.push(entry);
+      }
+      return attributes_in_json_format;
+    };
+
+    const createCapture = (
+      {
+        id,
+        time_created,
+        planter_photo_url,
+        gps_accuracy,
+        image_url,
+        lat,
+        lon,
+        morphology,
+        age,
+        note,
+        time_updated,
+      },
+      treeAttributes,
+      growerAccount
+    ) => {
+      return Object.freeze({
+        reference_id: id,
+        image_url: image_url,
+        lat: lat,
+        lon: lon,
+        gps_accuracy: gps_accuracy,
+        grower_id: growerAccount.id,
+        grower_photo_url: planter_photo_url,
+        grower_username: '-', //TODO: What should be used for username here?
+        morphology: morphology,
+        age: age,
+        note: note,
+        attributes: attributesFormatter(treeAttributes),
+        created_at: time_created,
+        updated_at: time_updated,
+        device_configuration_id: uuid_generate_v4(), // should this take value of device_identifier
+        session_id: uuid_generate_v4(), // TODO: Is this appropriate to generate uuid here?
+      });
+    };
+
+    if (rowCountResult > 0) {
+      const stream = knex.raw(`${base_query_string}`).stream();
+      stream.pipe(ws);
+    } 
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+migrate();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,487 @@
 {
   "name": "domain-migration-scripts",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "dotenv": "^10.0.0",
+        "knex": "^0.95.6",
+        "pg": "^7.4.0",
+        "pg-query-stream": "^4.1.0",
+        "progress": "^2.0.3",
+        "uuid": "^8.3.2"
+      },
+      "devDependencies": {
+        "db-migrate-pg": "^1.2.2",
+        "expect-runtime": "^0.10.1"
+      },
+      "engines": {
+        "node": ">=12.0.0 <13",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
+    "node_modules/buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/db-migrate-base": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/db-migrate-base/-/db-migrate-base-2.3.1.tgz",
+      "integrity": "sha512-HewYQ3HPmy7NOWmhhMLg9TzN1StEtSqGL3w8IbBRCxEsJ+oM3bDUQ/z5fqpYKfIUK07mMXieCmZYwFpwWkSHDw==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.1.1"
+      }
+    },
+    "node_modules/db-migrate-pg": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/db-migrate-pg/-/db-migrate-pg-1.2.2.tgz",
+      "integrity": "sha512-+rgrhGNWC2SzcfweopyZqOQ1Igz1RVFMUZwUs6SviHpOUzFwb0NZWkG0pw1GaO+JxTxS7VJjckUWkOwZbVYVag==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.1.1",
+        "db-migrate-base": "^2.3.0",
+        "pg": "^8.0.3",
+        "semver": "^5.0.3"
+      }
+    },
+    "node_modules/db-migrate-pg/node_modules/pg": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
+      "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.3.0",
+        "pg-protocol": "^1.5.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/db-migrate-pg/node_modules/pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
+      "dev": true
+    },
+    "node_modules/db-migrate-pg/node_modules/pg-pool": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
+      "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==",
+      "dev": true
+    },
+    "node_modules/db-migrate-pg/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expect-runtime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/expect-runtime/-/expect-runtime-0.10.1.tgz",
+      "integrity": "sha512-bmIK/B/5Ucv3cs9imx+1nk5uTlcK+GqUJ8hD79JUpR4DCEFd7dazyrlkgFetOANJieryrY+CQzjA2xTtYdOY+g==",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/getopts": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.5.tgz",
+      "integrity": "sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA=="
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
+    "node_modules/knex": {
+      "version": "0.95.6",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.6.tgz",
+      "integrity": "sha512-noRcmkJl1MdicUbezrcr8OtVLcqQ/cfLIwgAx5EaxNxQOIJff88rBeyLywUScGhQNd/b78DIKKXZzLMrm6h/cw==",
+      "dependencies": {
+        "colorette": "1.2.1",
+        "commander": "^7.1.0",
+        "debug": "4.3.1",
+        "escalade": "^3.1.1",
+        "esm": "^3.2.25",
+        "getopts": "2.2.5",
+        "interpret": "^2.2.0",
+        "lodash": "^4.17.21",
+        "pg-connection-string": "2.4.0",
+        "rechoir": "^0.7.0",
+        "resolve-from": "^5.0.0",
+        "tarn": "^3.0.1",
+        "tildify": "2.0.0"
+      },
+      "bin": {
+        "knex": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/pg": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
+      "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "0.1.3",
+        "pg-packet-stream": "^1.1.0",
+        "pg-pool": "^2.0.10",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
+    },
+    "node_modules/pg-cursor": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.6.0.tgz",
+      "integrity": "sha512-BFLg40CTgBJ+LX9EwqjztUYaKxpxLffMmDTmlQNMCustX/JxMTYimxRkdhZvPYZGp++/2LjuqkKtO5DVVq0FNg=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-packet-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
+      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
+    },
+    "node_modules/pg-pool": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg==",
+      "peerDependencies": {
+        "pg": ">5.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==",
+      "dev": true
+    },
+    "node_modules/pg-query-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.1.0.tgz",
+      "integrity": "sha512-QbupRwS1JHqRVmNLQax4dIENgi+HoT7ToEn+rCcWqsZ/fbjTVdV+RmeZJRSMIcDhza3CImb/yAsTN0g2UGy6vg==",
+      "dependencies": {
+        "pg-cursor": "^2.6.0"
+      }
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
+      "dependencies": {
+        "split2": "^3.1.1"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
+      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "dependencies": {
+        "resolve": "^1.9.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "node_modules/semver": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/tarn": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.1.tgz",
+      "integrity": "sha512-6usSlV9KyHsspvwu2duKH+FMUhqJnAh6J5J/4MITl8s94iSUQTLkJggdiewKv4RyARQccnigV48Z+khiuVZDJw==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/tildify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
+      "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  },
   "dependencies": {
     "bluebird": {
       "version": "3.7.2",
@@ -231,7 +710,8 @@
     "pg-pool": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
-      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg==",
+      "requires": {}
     },
     "pg-protocol": {
       "version": "1.5.0",
@@ -367,6 +847,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "dotenv": "^10.0.0",
         "knex": "^0.95.6",
-        "pg": "^7.4.0",
+        "pg": "^8.6.0",
         "pg-query-stream": "^4.1.0",
         "progress": "^2.0.3",
         "uuid": "^8.3.2"
@@ -20,7 +20,7 @@
         "expect-runtime": "^0.10.1"
       },
       "engines": {
-        "node": ">=12.0.0 <13",
+        "node": ">=16.0.0 <17",
         "npm": ">=6.0.0"
       }
     },
@@ -71,36 +71,6 @@
         "pg": "^8.0.3",
         "semver": "^5.0.3"
       }
-    },
-    "node_modules/db-migrate-pg/node_modules/pg": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
-      "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
-      "dev": true,
-      "dependencies": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
-        "pg-pool": "^3.3.0",
-        "pg-protocol": "^1.5.0",
-        "pg-types": "^2.1.0",
-        "pgpass": "1.x"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/db-migrate-pg/node_modules/pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
-      "dev": true
-    },
-    "node_modules/db-migrate-pg/node_modules/pg-pool": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
-      "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==",
-      "dev": true
     },
     "node_modules/db-migrate-pg/node_modules/semver": {
       "version": "5.7.1",
@@ -241,21 +211,28 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/pg": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
-      "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.1.tgz",
+      "integrity": "sha512-7bdYcv7V6U3KAtWjpQJJBww0UEsWuh4yQ/EjNf2HeO/NnvKjpvhEIe/A/TleP6wtmSKnUnghs5A9jUoK6iDdkA==",
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "0.1.3",
-        "pg-packet-stream": "^1.1.0",
-        "pg-pool": "^2.0.10",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.4.1",
+        "pg-protocol": "^1.5.0",
         "pg-types": "^2.1.0",
-        "pgpass": "1.x",
-        "semver": "4.3.2"
+        "pgpass": "1.x"
       },
       "engines": {
-        "node": ">= 4.5.0"
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/pg-connection-string": {
@@ -276,24 +253,18 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/pg-packet-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
-      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
-    },
     "node_modules/pg-pool": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
-      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.4.1.tgz",
+      "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ==",
       "peerDependencies": {
-        "pg": ">5.0"
+        "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
-      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==",
-      "dev": true
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
     },
     "node_modules/pg-query-stream": {
       "version": "4.1.0",
@@ -319,9 +290,9 @@
       }
     },
     "node_modules/pg/node_modules/pg-connection-string": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
     },
     "node_modules/pgpass": {
       "version": "1.0.4",
@@ -420,14 +391,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
-    "node_modules/semver": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -525,33 +488,6 @@
         "semver": "^5.0.3"
       },
       "dependencies": {
-        "pg": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
-          "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
-          "dev": true,
-          "requires": {
-            "buffer-writer": "2.0.0",
-            "packet-reader": "1.0.0",
-            "pg-connection-string": "^2.5.0",
-            "pg-pool": "^3.3.0",
-            "pg-protocol": "^1.5.0",
-            "pg-types": "^2.1.0",
-            "pgpass": "1.x"
-          }
-        },
-        "pg-connection-string": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-          "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
-          "dev": true
-        },
-        "pg-pool": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
-          "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==",
-          "dev": true
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -666,24 +602,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "pg": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
-      "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.1.tgz",
+      "integrity": "sha512-7bdYcv7V6U3KAtWjpQJJBww0UEsWuh4yQ/EjNf2HeO/NnvKjpvhEIe/A/TleP6wtmSKnUnghs5A9jUoK6iDdkA==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "0.1.3",
-        "pg-packet-stream": "^1.1.0",
-        "pg-pool": "^2.0.10",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.4.1",
+        "pg-protocol": "^1.5.0",
         "pg-types": "^2.1.0",
-        "pgpass": "1.x",
-        "semver": "4.3.2"
+        "pgpass": "1.x"
       },
       "dependencies": {
         "pg-connection-string": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-          "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+          "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
         }
       }
     },
@@ -702,22 +637,16 @@
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
-    "pg-packet-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
-      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
-    },
     "pg-pool": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
-      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.4.1.tgz",
+      "integrity": "sha512-TVHxR/gf3MeJRvchgNHxsYsTCHQ+4wm3VIHSS19z8NC0+gioEhq1okDY1sm/TYbfoP6JLFx01s0ShvZ3puP/iQ==",
       "requires": {}
     },
     "pg-protocol": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
-      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==",
-      "dev": true
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
     },
     "pg-query-stream": {
       "version": "4.1.0",
@@ -811,11 +740,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "semver": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
     },
     "split2": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "knex": "^0.95.6",
     "pg": "^7.4.0",
     "pg-query-stream": "^4.1.0",
-    "progress": "^2.0.3"
+    "progress": "^2.0.3",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "db-migrate-pg": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <13",
+    "node": ">=16.0.0 <17",
     "npm": ">=6.0.0"
   },
   "main": "index.js",
@@ -24,7 +24,7 @@
   "dependencies": {
     "dotenv": "^10.0.0",
     "knex": "^0.95.6",
-    "pg": "^7.4.0",
+    "pg": "^8.6.0",
     "pg-query-stream": "^4.1.0",
     "progress": "^2.0.3",
     "uuid": "^8.3.2"


### PR DESCRIPTION
This is an initial version of the etl script to load treetracker.capture with data from public.trees. This has been tested on dev db, but there aren't that many records with eligible records to migrate. So this needs to be tested in test db against some realistic data.

The intent of this pull request is to discuss outstanding questions related to
-  attributes in treetracker.grower_account that are either undefined in public.planter (like wallet, wallet_id)
-  attributes in treetracker.capture that are not found in public.trees (e.g. grower_username, device_configuration_id etc)
- other concerns to preserve the integrity of the data while migrating -- see comments in code

